### PR TITLE
Can't exclude inner classes because Scala expects them to exist.

### DIFF
--- a/language-adaptors/rxjava-clojure/build.gradle
+++ b/language-adaptors/rxjava-clojure/build.gradle
@@ -39,6 +39,10 @@ tasks.clojureTest {
     classpath = classpath + configurations.provided
 }
 
+tasks.compileExamplesClojure { 
+    classpath = classpath + configurations.provided
+}
+
 task createAdaptedObservable(type: JavaExec) { 
     main = 'rx.codegen.ClassPathBasedRunner'
     classpath = sourceSets.main.runtimeClasspath + configurations.provided

--- a/language-adaptors/rxjava-clojure/build.gradle
+++ b/language-adaptors/rxjava-clojure/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'osgi'
 
 dependencies {
     core project(':rxjava-core')
-    compile project(':rxjava-core')
-    compile project(':language-adaptors:codegen')
+    provided project(':rxjava-core')
+    provided project(':language-adaptors:codegen')
     compile 'org.clojure:clojure:1.4.+'
     compile 'clj-http:clj-http:0.6.4' // https://clojars.org/clj-http    
     provided 'junit:junit-dep:4.10'
@@ -35,9 +35,13 @@ eclipse {
   }
 }
 
+tasks.clojureTest { 
+    classpath = classpath + configurations.provided
+}
+
 task createAdaptedObservable(type: JavaExec) { 
     main = 'rx.codegen.ClassPathBasedRunner'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = sourceSets.main.runtimeClasspath + configurations.provided
     args = ["Clojure", codeGenOutputDir]
 
     inputs.files(sourceSets.main.runtimeClasspath)
@@ -48,7 +52,7 @@ tasks.test {
     dependsOn(createAdaptedObservable)
 
     //Reorders the classpath so that the newly-create Observables win
-    classpath = createAdaptedObservable.outputs.files + sourceSets.test.runtimeClasspath
+    classpath = createAdaptedObservable.outputs.files + configurations.provided + sourceSets.test.runtimeClasspath
 }
 
 tasks.jar {

--- a/language-adaptors/rxjava-dynamic/build.gradle
+++ b/language-adaptors/rxjava-dynamic/build.gradle
@@ -2,15 +2,15 @@ apply plugin: 'osgi'
 
 dependencies {
     core project(':rxjava-core')
-    compile project(':rxjava-core')
-    compile project(':language-adaptors:codegen')
+    provided project(':rxjava-core')
+    provided project(':language-adaptors:codegen')
     provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
 }
 
 task createAdaptedObservable(type: JavaExec) {  
     main = 'rx.codegen.ClassPathBasedRunner'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = sourceSets.main.runtimeClasspath + configurations.provided
     args = ["Dynamic", codeGenOutputDir]
 
     inputs.files(sourceSets.main.runtimeClasspath)

--- a/language-adaptors/rxjava-groovy/build.gradle
+++ b/language-adaptors/rxjava-groovy/build.gradle
@@ -26,6 +26,10 @@ tasks.test {
     classpath = createAdaptedObservable.outputs.files + sourceSets.test.runtimeClasspath
 }
 
+tasks.compileExamplesGroovy { 
+    classpath = classpath + configurations.provided
+}
+
 tasks.jar { 
     dependsOn(createAdaptedObservable)
 

--- a/language-adaptors/rxjava-groovy/build.gradle
+++ b/language-adaptors/rxjava-groovy/build.gradle
@@ -3,16 +3,16 @@ apply plugin: 'osgi'
 
 dependencies {
     core project(':rxjava-core')
-    compile project(':rxjava-core')
-    compile project(':language-adaptors:codegen')
-    groovy 'org.codehaus.groovy:groovy-all:2.+'
+    provided project(':rxjava-core')
+    provided project(':language-adaptors:codegen')
+    compile 'org.codehaus.groovy:groovy-all:2.+'
     provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
 }
 
 task createAdaptedObservable(type: JavaExec) {  
     main = 'rx.codegen.ClassPathBasedRunner'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = sourceSets.main.runtimeClasspath + configurations.provided
     args = ["Groovy", codeGenOutputDir]
 
     inputs.files(sourceSets.main.runtimeClasspath)

--- a/language-adaptors/rxjava-jruby/build.gradle
+++ b/language-adaptors/rxjava-jruby/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'osgi'
 
 dependencies {
     core project(':rxjava-core')
-    compile project(':rxjava-core')
-    compile project(':language-adaptors:codegen')
+    provided project(':rxjava-core')
+    provided project(':language-adaptors:codegen')
     compile 'org.jruby:jruby:1.6+'
     provided 'junit:junit-dep:4.10'
     provided 'org.mockito:mockito-core:1.8.5'
@@ -11,7 +11,7 @@ dependencies {
 
 task createAdaptedObservable(type: JavaExec) { 
     main = 'rx.codegen.ClassPathBasedRunner'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = sourceSets.main.runtimeClasspath + configurations.provided
     args = ["JRuby", codeGenOutputDir]
 
     inputs.files(sourceSets.main.runtimeClasspath)

--- a/language-adaptors/rxjava-scala/build.gradle
+++ b/language-adaptors/rxjava-scala/build.gradle
@@ -21,24 +21,23 @@ sourceSets {
 }
 
 dependencies {
-    // Scala compiler and related tools
-    compile 'org.scala-lang:scala-compiler:2.10+'
     compile 'org.scala-lang:scala-library:2.10+'
 
     compile project(':rxjava-core')
-    compile 'junit:junit-dep:4.10'
-    compile 'org.mockito:mockito-core:1.8.5'
-    compile 'org.scalatest:scalatest_2.10:1.9.1'
+
+    provided 'org.scalatest:scalatest_2.10:1.9.1'
+    provided 'junit:junit-dep:4.10'
+    provided 'org.mockito:mockito-core:1.8.5'
 }
 
 task test(overwrite: true, dependsOn: testClasses) << {
     ant.taskdef(name: 'scalatest',
-            classname: 'org.scalatest.tools.ScalaTestAntTask',
-            classpath: configurations.testRuntime.asPath + ':' + compileScala.destinationDir
-    )
+                classname: 'org.scalatest.tools.ScalaTestAntTask',
+                classpath: configurations.testRuntime.asPath + ':' + compileScala.destinationDir + ":" + configurations.provided.asPath
+               )
     ant.scalatest(runpath: sourceSets.test.output.classesDir,
-            haltonfailure: 'true',
-            fork: 'false') {reporter(type: 'stdout')}
+                  haltonfailure: 'true',
+                  fork: 'false') {reporter(type: 'stdout')}
 }
 
 jar {

--- a/rxjava-contrib/rxjava-swing/build.gradle
+++ b/rxjava-contrib/rxjava-swing/build.gradle
@@ -20,8 +20,6 @@ javadoc {
 }
 
 jar {
-    exclude('**/*$UnitTest*')
-
     manifest {
         name = 'rxjava-swing'
         instruction 'Bundle-Vendor', 'Netflix'

--- a/rxjava-core/build.gradle
+++ b/rxjava-core/build.gradle
@@ -25,10 +25,10 @@ javadoc {
 }
 
 jar {
-    archiveName = "rxjava-" + version + "." + extension
+    baseName = "rxjava"
 
     manifest {
-        name = 'rxjava-core'
+        name = 'rxjava'
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/RxJava'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'

--- a/rxjava-core/build.gradle
+++ b/rxjava-core/build.gradle
@@ -25,6 +25,8 @@ javadoc {
 }
 
 jar {
+    archiveName = "rxjava-" + version + "." + extension
+
     manifest {
         name = 'rxjava-core'
         instruction 'Bundle-Vendor', 'Netflix'


### PR DESCRIPTION
With Scala, it's not so easy to exclude the unit tests from the published JARs, unfortunately. The Scala compiler expects specified inner classes to actually exist in libraries.

This means that all JARs in RxJava modules which might be used by Scala have to include all their inner classes. Currently, this just applies to `rxjava-swing`, as far as I can see.

This PR simply removes excluding the unit tests from `rxjava-swing` from the Gradle build.
