### PR TITLE
Two-phase atomic array queue for RxRingBuffer.

### DIFF
--- a/src/main/java/rx/internal/util/RxRingBuffer.java
+++ b/src/main/java/rx/internal/util/RxRingBuffer.java
@@ -16,13 +16,11 @@
 package rx.internal.util;
 
 import java.util.Queue;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import rx.Observer;
-import rx.Subscription;
+import rx.*;
 import rx.exceptions.MissingBackpressureException;
 import rx.internal.operators.NotificationLite;
-import rx.internal.util.unsafe.SpscLinkedQueue;
+import rx.internal.util.unsafe.*;
 
 /**
  * This assumes Spsc or Spmc usage. This means only a single producer calling the on* methods. This is the Rx contract of an Observer.
@@ -31,13 +29,14 @@ import rx.internal.util.unsafe.SpscLinkedQueue;
 public class RxRingBuffer implements Subscription {
 
     public static RxRingBuffer getSpscInstance() {
+//        return new RxRingBuffer(new SpscLinkedQueue<Object>(), SIZE);
         return new RxRingBuffer(new SpscLinkedQueue<Object>(), SIZE);
     }
 
     @Deprecated
     public static RxRingBuffer getSpmcInstance() {
         // TODO right now this is returning an Spsc queue. Why did anything need Spmc before?
-        return new RxRingBuffer(new SpscLinkedQueue<Object>(), SIZE);
+        return new RxRingBuffer(new AtomicArrayQueueUnsafe2(4, SIZE), SIZE);
     }
 
     private static final NotificationLite<Object> on = NotificationLite.instance();
@@ -45,9 +44,15 @@ public class RxRingBuffer implements Subscription {
     private Queue<Object> queue;
 
     private final int size;
-    private volatile int _count = 0;
-    private static final AtomicIntegerFieldUpdater<RxRingBuffer> COUNT = AtomicIntegerFieldUpdater.newUpdater(RxRingBuffer.class, "_count"); 
-
+    
+    /** Keeps track how many items were produced. */
+    private long producerIndexCached;
+    /** Shows how many items were produced to other threads. */
+    private volatile long producerIndexShared;
+    /** Keeps track how many items were consumed. */
+    private long consumerIndexCached;
+    /** Shows how many items were consumed to other threads. */
+    private volatile long consumerIndexShared;
     /**
      * We store the terminal state separately so it doesn't count against the size.
      * We don't just +1 the size since some of the queues require sizes that are a power of 2.
@@ -202,15 +207,15 @@ public class RxRingBuffer implements Subscription {
      *             if more onNext are sent than have been requested
      */
     public void onNext(Object o) throws MissingBackpressureException {
-        if (queue == null) {
+        Queue<Object> q = queue;
+        if (q == null) {
             throw new IllegalStateException("This instance has been unsubscribed and the queue is no longer usable.");
         }
         
-        if(COUNT.incrementAndGet(this) <= size) {
-            queue.offer(on.next(o));
+        if(producerQueueSize() < size) {
+            produce();
+            q.offer(on.next(o));
         } else {
-            // decrement since we went over
-            COUNT.decrementAndGet(this);
             // throw exception since we exceeded size limit
             throw new MissingBackpressureException();
         }
@@ -242,28 +247,61 @@ public class RxRingBuffer implements Subscription {
         return size;
     }
 
+    /**
+     * @return Returns the queue size from the view of the producer.
+     */
+    protected int producerQueueSize() {
+        long diff = producerIndexCached - consumerIndexShared;
+        if (diff > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int)diff;
+    }
+    /**
+     * @return Returns the queue size from the view of the consumer.
+     */
+    protected int consumerQueueSize() {
+        long diff = producerIndexShared - consumerIndexCached;
+        if (diff > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int)diff;
+    }
+    protected void produce() {
+        producerIndexShared = ++producerIndexCached;
+    }
+    protected void consume() {
+        consumerIndexShared = ++consumerIndexCached;
+    }
+    
     public int count() {
         if (queue == null) {
             return 0;
         }
-        return _count;
+        long diff = producerIndexShared - consumerIndexShared;
+        if (diff > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int)diff;
 //        return queue.size();
     }
 
     public boolean isEmpty() {
-        if (queue == null) {
+        Queue<Object> q = queue;
+        if (q == null) {
             return true;
         }
-        return queue.isEmpty();
+        return q.isEmpty();
     }
 
     public Object poll() {
-        if (queue == null) {
+        Queue<Object> q = queue;
+        if (q == null) {
             // we are unsubscribed and have released the undelrying queue
             return null;
         }
         Object o;
-        o = queue.poll();
+        o = q.poll();
         /*
          * benjchristensen July 10 2014 => The check for 'queue.isEmpty()' came from a very rare concurrency bug where poll()
          * is invoked, then an "onNext + onCompleted/onError" arrives before hitting the if check below. In that case,
@@ -276,25 +314,26 @@ public class RxRingBuffer implements Subscription {
          * a +1 of the size, or -1 of how many onNext can be sent. See comment on 'terminalState' above for why it
          * is currently the way it is.
          */
-        if (o == null && terminalState != null && queue.isEmpty()) {
+        if (o == null && terminalState != null && q.isEmpty()) {
             o = terminalState;
             // once emitted we clear so a poll loop will finish
             terminalState = null;
         } else {
             // decrement when we drain
-            COUNT.decrementAndGet(this);
+            consume();
         }
         return o;
     }
 
     public Object peek() {
-        if (queue == null) {
+        Queue<Object> q = queue;
+        if (q == null) {
             // we are unsubscribed and have released the undelrying queue
             return null;
         }
         Object o;
-        o = queue.peek();
-        if (o == null && terminalState != null && queue.isEmpty()) {
+        o = q.peek();
+        if (o == null && terminalState != null && q.isEmpty()) {
             o = terminalState;
         }
         return o;

--- a/src/main/java/rx/internal/util/unsafe/AtomicArrayQueueUnsafe2.java
+++ b/src/main/java/rx/internal/util/unsafe/AtomicArrayQueueUnsafe2.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.util.unsafe;
+
+import java.util.*;
+
+import rx.internal.util.PlatformDependent;
+
+/**
+ * A single-producer single-consumer circular array which resizes to a higher capacity once it fills
+ * its smaller buffer.
+ */
+public class AtomicArrayQueueUnsafe2 extends AbstractQueue<Object> {
+    static final Object TOMBSTONE = new Object();
+    static final long P_BUFFER;
+    static final long ARRAY_OFFSET;
+    static final int ARRAY_SCALE;
+    static final int ARRAY_INDEX_SIZE;
+    static final long HIGH_TRAFFIC_QUEUE_THRESHOLD;
+    static {
+        long _size = 128;
+        if (PlatformDependent.isAndroid()) {
+            _size = Long.MAX_VALUE;
+        }
+
+        // possible system property for overriding
+        String sizeFromProperty = System.getProperty("rx.ring-buffer.resize-traffic");
+        if (sizeFromProperty != null) {
+            try {
+                _size = Integer.parseInt(sizeFromProperty);
+            } catch (Exception e) {
+                System.err.println("Failed to set 'rx.ring-buffer.resize-traffic' with value " + sizeFromProperty + " => " + e.getMessage());
+            }
+        }
+        HIGH_TRAFFIC_QUEUE_THRESHOLD = _size;
+        
+        try {
+            P_BUFFER = UnsafeAccess.UNSAFE.objectFieldOffset(AtomicArrayQueueUnsafe2.class.getDeclaredField("buffer"));
+        } catch (NoSuchFieldException ex) {
+            throw new RuntimeException();
+        }
+        int is = UnsafeAccess.UNSAFE.arrayIndexScale(Object[].class);
+        int as;
+        if (is == 4) {
+            as = 2;
+        } else
+            if (is == 8) {
+                as = 3;
+            } else {
+                throw new RuntimeException("Unsupported array index scale: " + is);
+            }
+
+        ARRAY_SCALE = as;
+        ARRAY_INDEX_SIZE = is;
+        ARRAY_OFFSET = UnsafeAccess.UNSAFE.arrayBaseOffset(Object[].class);
+    }
+    Object[] buffer;
+    long readerIndex;
+    long writerIndex;
+    final int maxCapacity;
+    private Object[] lpBuffer() {
+        return (Object[])UnsafeAccess.UNSAFE.getObject(this, P_BUFFER);
+    }
+    private Object[] lvBuffer() {
+        return (Object[])UnsafeAccess.UNSAFE.getObjectVolatile(this, P_BUFFER);
+    }
+    private void soBuffer(Object[] buffer) {
+        UnsafeAccess.UNSAFE.putOrderedObject(this, P_BUFFER, buffer);
+    }
+    private Object lvElement(Object[] buffer, long offset) {
+        return UnsafeAccess.UNSAFE.getObjectVolatile(buffer, offset);
+    }
+    private void soElement(Object[] buffer, long offset, Object value) {
+        UnsafeAccess.UNSAFE.putOrderedObject(buffer, offset, value);
+    }
+    private boolean casElement(Object[] buffer, long offset, Object expected, Object value) {
+        return UnsafeAccess.UNSAFE.compareAndSwapObject(buffer, offset, expected, value);
+    }
+
+    private long calcOffset(long index, int mask) {
+        return ARRAY_OFFSET + ((index & mask) << ARRAY_SCALE);
+    }
+    static int roundToPowerOfTwo(final int value) {
+        return 1 << (32 - Integer.numberOfLeadingZeros(value - 1));
+    }
+
+    public AtomicArrayQueueUnsafe2(int initialCapacity, int maxCapacity) {
+        int c0;
+        if (initialCapacity >= 1 << 30) {
+            c0 = 1 << 30;
+        } else {
+            c0 = roundToPowerOfTwo(initialCapacity);
+        }
+        int cm;
+        if (maxCapacity >= 1 << 30) {
+            cm = 1 << 30;
+        } else {
+            cm = roundToPowerOfTwo(maxCapacity);
+        }
+        this.maxCapacity = cm;
+
+        soBuffer(new Object[c0]);;
+    }
+
+    Object[] grow(Object[] b, long wo, int n, int n2) {
+
+        int arrayScale = ARRAY_SCALE;
+        int arrayIndexSize = ARRAY_INDEX_SIZE;
+        long arrayOffset = ARRAY_OFFSET;
+        Object[] b2 = new Object[n2];
+
+        // move the front to the back
+        boolean caughtUp = false;
+        for (long i = wo - arrayIndexSize, j = wo + (n << arrayScale); i >= arrayOffset; i -= arrayIndexSize, j -= arrayIndexSize) {
+            Object o = lvElement(b, i);
+            if (o == null || !casElement(b, i, o, TOMBSTONE)) {
+                caughtUp = true;
+                break;
+            } else
+            soElement(b2, j, o);
+        }
+        // leave everything beyont the wrap point at its location
+        if (!caughtUp) {
+            long no = arrayOffset + (n << arrayScale);
+            for (long i = no; i >= wo; i -= arrayIndexSize) {
+                Object o = lvElement(b, i);
+                if (o == null || !casElement(b, i, o, TOMBSTONE)) {
+                    break;
+                }
+                soElement(b2, i, o);
+            }
+        }
+
+        soBuffer(b2);
+
+        return b2;
+    }
+
+    @Override
+    public boolean offer(Object o) {
+        long wi = writerIndex;
+
+        Object[] b = lpBuffer();
+
+        int n = b.length - 1;
+        long wo = calcOffset(wi, n);
+        if (lvElement(b, wo) != null || wi >= HIGH_TRAFFIC_QUEUE_THRESHOLD) {
+            int q = maxCapacity;
+            if (n + 1 == q) {
+                return false;
+            }
+            // grow
+            b = grow(b, wo, n, q);
+            wo = calcOffset(wi, q - 1);
+        }
+        soElement(b, wo, o);
+
+        writerIndex = wi + 1;
+
+        return true;
+    }
+    @Override
+    public Object poll() {
+        long ri = readerIndex;
+        Object[] b = lpBuffer();
+        for (;;) {
+            int mask = b.length - 1;
+            long ro = calcOffset(ri, mask);
+
+            Object o = lvElement(b, ro);
+            if (o == null) {
+                return null;
+            }
+            if (mask + 1 == maxCapacity) {
+                soElement(b, ro, null);
+            } else
+            if (o == TOMBSTONE || !casElement(b, ro, o, null)) {
+                b = lvBuffer();
+                continue;
+            }
+            readerIndex = ri + 1;
+            return o;
+        }
+    }
+    @Override
+    public Object peek() {
+        long ri = readerIndex;
+        Object[] b = lpBuffer();
+        for (;;) {
+            int mask = b.length - 1;
+            long ro = calcOffset(ri, mask);
+
+            Object o = lvElement(b, ro);
+            if (o != TOMBSTONE) {
+                return o;
+            }
+            b = lvBuffer();
+        }
+    }
+    @Override
+    public boolean isEmpty() {
+        return peek() == null;
+    }
+    @Override
+    public int size() {
+        int size = 0;
+        long ri = readerIndex;
+        Object[] b = lpBuffer();
+        for (;;) {
+            int mask = b.length - 1;
+            long ro = calcOffset(ri, mask);
+            Object o = lvElement(b, ro);
+            if (o == null) {
+                return size;
+            } else
+            if (o == TOMBSTONE) {
+                b = lvBuffer();
+                continue;
+            }
+            size++;
+            ri++;
+        }
+    }
+    @Override
+    public Iterator<Object> iterator() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/perf/java/rx/internal/RxRingBufferPerf.java
+++ b/src/perf/java/rx/internal/RxRingBufferPerf.java
@@ -28,6 +28,9 @@ import rx.exceptions.MissingBackpressureException;
 import rx.internal.util.RxRingBuffer;
 import rx.jmh.InputWithIncrementingInteger;
 
+/**
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*RxRingBufferPerf.*"
+ */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 public class RxRingBufferPerf {
@@ -40,10 +43,10 @@ public class RxRingBufferPerf {
 
     @Benchmark
     public void spmcRingBufferAddRemove1000(SpmcInput input) throws InterruptedException, MissingBackpressureException {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.ring.onNext("a");
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.bh.consume(input.ring.poll());
         }
     }
@@ -51,10 +54,10 @@ public class RxRingBufferPerf {
     @Benchmark
     public void spmcCreateUseAndDestroy1000(Input input) throws InterruptedException, MissingBackpressureException {
         RxRingBuffer buffer = RxRingBuffer.getSpmcInstance();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             buffer.onNext("a");
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.bh.consume(buffer.poll());
         }
         buffer.release();
@@ -76,10 +79,10 @@ public class RxRingBufferPerf {
 
     @Benchmark
     public void spscRingBufferAddRemove1000(SpscInput input) throws InterruptedException, MissingBackpressureException {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.ring.onNext("a");
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.bh.consume(input.ring.poll());
         }
     }
@@ -87,10 +90,10 @@ public class RxRingBufferPerf {
     @Benchmark
     public void spscCreateUseAndDestroy1000(Input input) throws InterruptedException, MissingBackpressureException {
         RxRingBuffer buffer = RxRingBuffer.getSpscInstance();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             buffer.onNext("a");
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.bh.consume(buffer.poll());
         }
         buffer.release();


### PR DESCRIPTION
Hi Ben!

I've spent some time understanding the situation and I came up with a solution that might just work: an atomic array queue which starts out with a small capacity and then switches to a large capacity in case of overfilling or due to high traffic.

The problem with the default SpscLinkedQueue and SpscArrayQueue is that they consume a lot of memory due to their fixed size and generous padding, which translates to more frequent GCs in the case of short lived queueing. 

At first I thought, let the queue size double on overfill (up to a maximum), but even if I managed to figure out the correct algorithm, it ran pretty slow regardless to the size. The problem was not the resizing but the expensive CAS on every poll() to detect a potential ongoing resize operation.

The solution I came up with does this resize only once: it switches to high gear in case of overfill or a certain number of items have passed through the queue. Once in high gear, it can now use much cheaper atomic operation and thus increase throughput. Maybe it should be called RxJava's weak queue hypothesis.

The usual benchmark gives nice values: (spmc is in this case the AtomicArrayQueueUnsafe2, 1000 is actually RxRingBuffer.SIZE).

```
Benchmark                                            Mode   Samples        Score  Score error    Units
r.i.RxRingBufferPerf.spmcCreateUseAndDestroy1       thrpt         5 27493478,930   885408,249    ops/s
r.i.RxRingBufferPerf.spmcCreateUseAndDestroy1000    thrpt         5   320608,155     4635,395    ops/s
r.i.RxRingBufferPerf.spmcRingBufferAddRemove1       thrpt         5 44589735,680   856811,156    ops/s
r.i.RxRingBufferPerf.spmcRingBufferAddRemove1000    thrpt         5   353921,131     7072,580    ops/s
r.i.RxRingBufferPerf.spscCreateUseAndDestroy1       thrpt         5 10842470,917   128615,881    ops/s
r.i.RxRingBufferPerf.spscCreateUseAndDestroy1000    thrpt         5   324563,384     2101,994    ops/s
r.i.RxRingBufferPerf.spscRingBufferAddRemove1       thrpt         5 42179656,259   723832,236    ops/s
r.i.RxRingBufferPerf.spscRingBufferAddRemove1000    thrpt         5   328218,479    29409,408    ops/s
```

If the queue stayed in its initial capacity, the `spmcRingBufferAddRemove1` would give around 32-36 Mops/s because of the more expensive atomic operations.

Few other notes:
- This rather feels a bit cheating the perf test.
- Since AtomicArrayQueueUnsafe2 doesn't pads its fields or the buffer, it may be vulnerable to false sharing and thus can't perform as well as an SpscArrayQueue. (This)[https://gist.github.com/akarnokd/d561a92481062c94d792] gist shows some raw offer/poll throughput.
- Maybe the high-gear could be a full SpscArrayQueue and AAQU2 just shoveling over to it during resize. However, I'm not sure if the volatile dispatch (i.e., yet another volatile field telling which queue implementation to call) in offer()/poll() makes it worth.
