### PR TITLE
RxRingBuffer enhanced performance and some measurements.

### DIFF
--- a/src/main/java/rx/internal/operators/OperatorMerge.java
+++ b/src/main/java/rx/internal/operators/OperatorMerge.java
@@ -629,7 +629,7 @@ public class OperatorMerge<T> implements Operator<T, Observable<? extends T>> {
                     } else {
                         // this needs to check q.count() as draining above may not have drained the full queue
                         // perf tests show this to be okay, though different queue implementations could perform poorly with this
-                        if (producer.requested > 0 && q.count() == 0) {
+                        if (producer.requested > 0 && q.isEmpty()) {
                             if (complete) {
                                 parentSubscriber.completeInner(this);
                             } else {

--- a/src/main/java/rx/internal/util/AtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/AtomicArrayQueue.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.util;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import rx.internal.util.unsafe.Pow2;
+
+/**
+ * 
+ */
+public class AtomicArrayQueue extends AbstractQueue<Object> {
+    static final Object TOMBSTONE = new Object();
+    static final int indexPad = 16; // 64 bytes between longs
+    static final int indexShift = 4; // 64 bytes between array elements
+    static final int HIGH_TRAFFIC = 128;
+    final int smallMask;
+    final int largeMask;
+    long[] readerIndex;
+    long[] writerIndex;
+    final AtomicReference<AtomicReferenceArray<Object>> buffer;
+    
+    public AtomicArrayQueue(int initial, int maxCapacity) {
+        int is = Pow2.roundToPowerOfTwo(initial);
+        int ms = Pow2.roundToPowerOfTwo(maxCapacity);
+        
+        this.smallMask = is - 1;
+        this.largeMask = ms - 1;
+        
+        readerIndex = new long[1];
+        writerIndex = new long[1];
+        AtomicReferenceArray<Object> b = new AtomicReferenceArray<Object>(is);
+        buffer = new AtomicReference<AtomicReferenceArray<Object>>(b);
+    }
+    
+    long lpReaderIndexSmall() {
+        return readerIndex[0];
+    }
+    void spReaderIndexSmall(long value) {
+        readerIndex[0] = value;
+    }
+
+    long lpWriterIndexSmall() {
+        return writerIndex[0];
+    }
+    void spWriterIndexSmall(long value) {
+        writerIndex[0] = value;
+    }
+
+    
+    long lpReaderIndexLarge() {
+        if (readerIndex.length == 1) {
+            long ri = readerIndex[0];
+            readerIndex = new long[2 * indexPad];
+            readerIndex[indexPad] = ri;
+            return ri;
+        }
+        return readerIndex[indexPad];
+    }
+    long lpWriterIndexLarge() {
+        return writerIndex[indexPad];
+    }
+    
+    void spReaderIndexLarge(long value) {
+        readerIndex[indexPad] = value;
+    }
+    void spWriterIndexLarge(long value) {
+        writerIndex[indexPad] = value;
+    }
+    
+    AtomicReferenceArray<Object> lvBuffer() {
+        return buffer.get();
+    }
+    void soBuffer(AtomicReferenceArray<Object> b) {
+        buffer.lazySet(b);
+    }
+    
+    Object lvElement(AtomicReferenceArray<Object> b, int offset) {
+        return b.get(offset);
+    }
+    void soElement(AtomicReferenceArray<Object> b, int offset, Object value) {
+        b.lazySet(offset, value);
+    }
+    boolean casElement(AtomicReferenceArray<Object> b, int offset, Object expected, Object value) {
+        return b.compareAndSet(offset, expected, value);
+    }
+    
+    int offsetSmall(long index, int mask) {
+        return ((int) index & mask);
+    }
+    
+    int offsetLarge(long index, int mask) {
+        return indexPad + ((int) index & mask) << indexShift;
+    }
+    
+    AtomicReferenceArray<Object> grow(AtomicReferenceArray<Object> b, long wi, int wo, int smallMask, int largeMask) {
+        int len2 = indexPad * 2 + (largeMask + 1) << indexShift;
+        AtomicReferenceArray<Object> b2 = new AtomicReferenceArray<Object>(len2);
+        
+        boolean caughtUp = false;
+        int j = offsetLarge(wi, largeMask);
+        for (int i = wo - 1; i >= 0; i--, j -= indexPad) {
+            Object o = lvElement(b, i);
+            if (o == null || !casElement(b, i, o, TOMBSTONE)) {
+                caughtUp = true;
+                break;
+            }
+            soElement(b2, j, o);
+        }
+        if (!caughtUp) {
+            for (int i = largeMask; i >= wo; i--, j -= indexPad) {
+                Object o = lvElement(b, i);
+                if (o == null || !casElement(b, i, o, TOMBSTONE)) {
+                    break;
+                }
+                soElement(b2, j, o);
+            }
+        }
+        
+        writerIndex = new long[2 * indexPad];
+        spWriterIndexLarge(wi);
+        soBuffer(b2);
+        
+        return b2;
+    }
+    
+    @Override
+    public boolean offer(Object o) {
+        AtomicReferenceArray<Object> b = lvBuffer();
+        int lm = largeMask;
+        if (b.length() > lm + 1) {
+            long wi = lpWriterIndexLarge();
+            int wo = offsetLarge(wi, lm);
+            if (lvElement(b, wo) != null) {
+                return false;
+            }
+            soElement(b, wo, o);
+            spWriterIndexLarge(wi + 1);
+        } else {
+            int sm = smallMask;
+            long wi = lpWriterIndexSmall();
+            int wo = offsetSmall(wi, sm);
+            if (lvElement(b, wo) != null || wi >= HIGH_TRAFFIC) {
+                b = grow(b, wi, wo, sm, lm);
+                wo = offsetLarge(wi, lm);
+                soElement(b, wo, o);
+                spWriterIndexLarge(wi + 1);
+            } else {
+                soElement(b, wo, o);
+                spWriterIndexSmall(wi + 1);
+            }
+        }
+        return true;
+    }
+    @Override
+    public Object poll() {
+        int lm = largeMask;
+        int sm = smallMask;
+        for (;;) {
+            AtomicReferenceArray<Object> b = lvBuffer();
+            if (b.length() > lm + 1) {
+                long ri = lpReaderIndexLarge();
+                int ro = offsetLarge(ri, lm);
+                Object o = lvElement(b, ro);
+                if (o == null) {
+                    return null;
+                }
+                soElement(b, ro, null);
+                spReaderIndexLarge(ri + 1);
+            } else {
+                long ri = lpReaderIndexSmall();
+                int ro = offsetSmall(ri, sm);
+                Object o = lvElement(b, ro);
+                if (o == null) {
+                    return null;
+                } else
+                if (o == TOMBSTONE || !casElement(b, ro, o, null)) {
+                    continue;
+                }
+                spReaderIndexSmall(ri + 1);
+                return o;
+            }
+        }
+    }
+    @Override
+    public Object peek() {
+        throw new UnsupportedOperationException();
+    }
+    @Override
+    public Iterator<Object> iterator() {
+        throw new UnsupportedOperationException();
+    }
+    @Override
+    public int size() {
+        return 0;
+    }
+}

--- a/src/main/java/rx/internal/util/AtomicArrayQueue.java
+++ b/src/main/java/rx/internal/util/AtomicArrayQueue.java
@@ -21,73 +21,117 @@ import java.util.concurrent.atomic.*;
 
 import rx.internal.util.unsafe.Pow2;
 
-/**
- * 
- */
-public class AtomicArrayQueue extends AbstractQueue<Object> {
+abstract class AtomicArrayQueueP0 extends AbstractQueue<Object> {
+//    long p00, p01, p02, p03, p04, p05, p06;
+}
+
+abstract class AtomicArrayQueueCold extends AtomicArrayQueueP0 {
     static final Object TOMBSTONE = new Object();
     static final int indexPad = 16; // 64 bytes between longs
     static final int indexShift = 4; // 64 bytes between array elements
-    static final int HIGH_TRAFFIC = 128;
+    static final long HIGH_TRAFFIC_QUEUE_THRESHOLD;
+    static {
+        long _size = 128;
+        if (PlatformDependent.isAndroid()) {
+            _size = Long.MAX_VALUE;
+        }
+
+        // possible system property for overriding
+        String sizeFromProperty = System.getProperty("rx.ring-buffer.resize-traffic");
+        if (sizeFromProperty != null) {
+            try {
+                _size = Integer.parseInt(sizeFromProperty);
+            } catch (Exception e) {
+                System.err.println("Failed to set 'rx.ring-buffer.resize-traffic' with value " + sizeFromProperty + " => " + e.getMessage());
+            }
+        }
+        HIGH_TRAFFIC_QUEUE_THRESHOLD = _size;
+    }
     final int smallMask;
     final int largeMask;
-    long[] readerIndex;
-    long[] writerIndex;
-    final AtomicReference<AtomicReferenceArray<Object>> buffer;
-    
-    public AtomicArrayQueue(int initial, int maxCapacity) {
+    public AtomicArrayQueueCold(int initial, int maxCapacity) {
         int is = Pow2.roundToPowerOfTwo(initial);
         int ms = Pow2.roundToPowerOfTwo(maxCapacity);
         
         this.smallMask = is - 1;
         this.largeMask = ms - 1;
-        
-        readerIndex = new long[1];
-        writerIndex = new long[1];
-        AtomicReferenceArray<Object> b = new AtomicReferenceArray<Object>(is);
-        buffer = new AtomicReference<AtomicReferenceArray<Object>>(b);
+    }    
+}
+abstract class AtomicArrayQueueP1 extends AtomicArrayQueueCold {
+//    long p10, p11, p12, p13, p14, p15, p16, p17;
+    public AtomicArrayQueueP1(int initial, int maxCapacity) {
+        super(initial, maxCapacity);
+    }
+}
+abstract class AtomicArrayQueueReader extends AtomicArrayQueueP1 {
+    long readerIndex;
+    public AtomicArrayQueueReader(int initial, int maxCapacity) {
+        super(initial, maxCapacity);
+    }
+}
+
+abstract class AtomicArrayQueueP2 extends AtomicArrayQueueReader {
+//    long p20, p21, p22, p23, p24, p25, p26;
+    public AtomicArrayQueueP2(int initial, int maxCapacity) {
+        super(initial, maxCapacity);
+    }
+}
+
+abstract class AtomicArrayQueueWriter extends AtomicArrayQueueP2 {
+    long writerIndex;
+    public AtomicArrayQueueWriter(int initial, int maxCapacity) {
+        super(initial, maxCapacity);
+    }
+}
+
+abstract class AtomicArrayQueueP3 extends AtomicArrayQueueWriter {
+//    long p30, p31, p32, p33, p34, p35, p36;
+    public AtomicArrayQueueP3(int initial, int maxCapacity) {
+        super(initial, maxCapacity);
+    }
+}
+abstract class AtomicArrayQueueBuffer extends AtomicArrayQueueP3 {
+    volatile AtomicReferenceArray<Object> buffer;
+    public AtomicArrayQueueBuffer(int initial, int maxCapacity) {
+        super(initial, maxCapacity);
+        buffer = new AtomicReferenceArray<Object>(this.smallMask + 1);
+    }
+}
+abstract class AtomicArrayQueueP4 extends AtomicArrayQueueBuffer {
+//    long p40, p41, p42, p43, p44, p45, p46;
+    public AtomicArrayQueueP4(int initial, int maxCapacity) {
+        super(initial, maxCapacity);
+    }
+}
+
+/**
+ * 
+ */
+public class AtomicArrayQueue extends AtomicArrayQueueP4 {
+    
+    public AtomicArrayQueue(int initial, int maxCapacity) {
+        super(initial, maxCapacity);
     }
     
-    long lpReaderIndexSmall() {
-        return readerIndex[0];
+    long lpReaderIndex() {
+        return readerIndex;
     }
-    void spReaderIndexSmall(long value) {
-        readerIndex[0] = value;
+    void spReaderIndex(long value) {
+        readerIndex = value;
     }
 
-    long lpWriterIndexSmall() {
-        return writerIndex[0];
+    long lpWriterIndex() {
+        return writerIndex;
     }
-    void spWriterIndexSmall(long value) {
-        writerIndex[0] = value;
+    void spWriterIndex(long value) {
+        writerIndex = value;
     }
 
-    
-    long lpReaderIndexLarge() {
-        if (readerIndex.length == 1) {
-            long ri = readerIndex[0];
-            readerIndex = new long[2 * indexPad];
-            readerIndex[indexPad] = ri;
-            return ri;
-        }
-        return readerIndex[indexPad];
-    }
-    long lpWriterIndexLarge() {
-        return writerIndex[indexPad];
-    }
-    
-    void spReaderIndexLarge(long value) {
-        readerIndex[indexPad] = value;
-    }
-    void spWriterIndexLarge(long value) {
-        writerIndex[indexPad] = value;
-    }
-    
     AtomicReferenceArray<Object> lvBuffer() {
-        return buffer.get();
+        return buffer;
     }
     void soBuffer(AtomicReferenceArray<Object> b) {
-        buffer.lazySet(b);
+        buffer = b;
     }
     
     Object lvElement(AtomicReferenceArray<Object> b, int offset) {
@@ -113,7 +157,7 @@ public class AtomicArrayQueue extends AbstractQueue<Object> {
         AtomicReferenceArray<Object> b2 = new AtomicReferenceArray<Object>(len2);
         
         boolean caughtUp = false;
-        int j = offsetLarge(wi, largeMask);
+        int j = offsetLarge(wi, largeMask) - indexPad;
         for (int i = wo - 1; i >= 0; i--, j -= indexPad) {
             Object o = lvElement(b, i);
             if (o == null || !casElement(b, i, o, TOMBSTONE)) {
@@ -123,7 +167,7 @@ public class AtomicArrayQueue extends AbstractQueue<Object> {
             soElement(b2, j, o);
         }
         if (!caughtUp) {
-            for (int i = largeMask; i >= wo; i--, j -= indexPad) {
+            for (int i = smallMask; i >= wo; i--, j -= indexPad) {
                 Object o = lvElement(b, i);
                 if (o == null || !casElement(b, i, o, TOMBSTONE)) {
                     break;
@@ -132,8 +176,6 @@ public class AtomicArrayQueue extends AbstractQueue<Object> {
             }
         }
         
-        writerIndex = new long[2 * indexPad];
-        spWriterIndexLarge(wi);
         soBuffer(b2);
         
         return b2;
@@ -141,49 +183,47 @@ public class AtomicArrayQueue extends AbstractQueue<Object> {
     
     @Override
     public boolean offer(Object o) {
+        long wi = lpWriterIndex();
         AtomicReferenceArray<Object> b = lvBuffer();
         int lm = largeMask;
-        if (b.length() > lm + 1) {
-            long wi = lpWriterIndexLarge();
+        int bl = b.length();
+        if (bl > lm + 1) {
             int wo = offsetLarge(wi, lm);
             if (lvElement(b, wo) != null) {
                 return false;
             }
             soElement(b, wo, o);
-            spWriterIndexLarge(wi + 1);
         } else {
             int sm = smallMask;
-            long wi = lpWriterIndexSmall();
             int wo = offsetSmall(wi, sm);
-            if (lvElement(b, wo) != null || wi >= HIGH_TRAFFIC) {
+            if (lvElement(b, wo) != null || wi >= HIGH_TRAFFIC_QUEUE_THRESHOLD) {
                 b = grow(b, wi, wo, sm, lm);
                 wo = offsetLarge(wi, lm);
                 soElement(b, wo, o);
-                spWriterIndexLarge(wi + 1);
             } else {
                 soElement(b, wo, o);
-                spWriterIndexSmall(wi + 1);
             }
         }
+        spWriterIndex(wi + 1);
         return true;
     }
     @Override
     public Object poll() {
         int lm = largeMask;
         int sm = smallMask;
+        long ri = lpReaderIndex();
         for (;;) {
             AtomicReferenceArray<Object> b = lvBuffer();
             if (b.length() > lm + 1) {
-                long ri = lpReaderIndexLarge();
                 int ro = offsetLarge(ri, lm);
                 Object o = lvElement(b, ro);
                 if (o == null) {
                     return null;
                 }
                 soElement(b, ro, null);
-                spReaderIndexLarge(ri + 1);
+                spReaderIndex(ri + 1);
+                return o;
             } else {
-                long ri = lpReaderIndexSmall();
                 int ro = offsetSmall(ri, sm);
                 Object o = lvElement(b, ro);
                 if (o == null) {
@@ -192,14 +232,30 @@ public class AtomicArrayQueue extends AbstractQueue<Object> {
                 if (o == TOMBSTONE || !casElement(b, ro, o, null)) {
                     continue;
                 }
-                spReaderIndexSmall(ri + 1);
+                spReaderIndex(ri + 1);
                 return o;
             }
         }
     }
     @Override
     public Object peek() {
-        throw new UnsupportedOperationException();
+        int lm = largeMask;
+        int sm = smallMask;
+        long ri = lpReaderIndex();
+        for (;;) {
+            AtomicReferenceArray<Object> b = lvBuffer();
+            if (b.length() > lm + 1) {
+                int ro = offsetLarge(ri, lm);
+                Object o = lvElement(b, ro);
+                return o;
+            } else {
+                int ro = offsetSmall(ri, sm);
+                Object o = lvElement(b, ro);
+                if (o != TOMBSTONE) {
+                    return o;
+                }
+            }
+        }
     }
     @Override
     public Iterator<Object> iterator() {

--- a/src/main/java/rx/internal/util/AtomicArrayQueuePadded.java
+++ b/src/main/java/rx/internal/util/AtomicArrayQueuePadded.java
@@ -187,7 +187,7 @@ public class AtomicArrayQueuePadded extends AtomicArrayQueueP4 {
         AtomicReferenceArray<Object> b = lvBuffer();
         int lm = largeMask;
         int bl = b.length();
-        if (bl > lm + 1) {
+        if (bl > lm) {
             int wo = offsetLarge(wi, lm);
             if (lvElement(b, wo) != null) {
                 return false;
@@ -214,7 +214,7 @@ public class AtomicArrayQueuePadded extends AtomicArrayQueueP4 {
         long ri = lpReaderIndex();
         for (;;) {
             AtomicReferenceArray<Object> b = lvBuffer();
-            if (b.length() > lm + 1) {
+            if (b.length() > lm) {
                 int ro = offsetLarge(ri, lm);
                 Object o = lvElement(b, ro);
                 if (o == null) {
@@ -244,7 +244,7 @@ public class AtomicArrayQueuePadded extends AtomicArrayQueueP4 {
         long ri = lpReaderIndex();
         for (;;) {
             AtomicReferenceArray<Object> b = lvBuffer();
-            if (b.length() > lm + 1) {
+            if (b.length() > lm) {
                 int ro = offsetLarge(ri, lm);
                 Object o = lvElement(b, ro);
                 return o;
@@ -263,6 +263,33 @@ public class AtomicArrayQueuePadded extends AtomicArrayQueueP4 {
     }
     @Override
     public int size() {
-        return 0;
+        int result = 0;
+        int lm = largeMask;
+        int sm = smallMask;
+        long ri = lpReaderIndex();
+        AtomicReferenceArray<Object> b = lvBuffer();
+        for (;;) {
+            if (b.length() > lm) {
+                int ro = offsetLarge(ri, lm);
+                Object o = lvElement(b, ro);
+                if (o == null) {
+                    return result;
+                }
+                result++;
+                ri++;
+            } else {
+                int ro = offsetSmall(ri, sm);
+                Object o = lvElement(b, ro);
+                if (o == null) {
+                    return result;
+                } else
+                if (o == TOMBSTONE) {
+                    b = lvBuffer();
+                } else {
+                    result++;
+                    ri++;
+                }
+            }
+        }
     }
 }

--- a/src/main/java/rx/internal/util/DiagnosticSpscQueue.java
+++ b/src/main/java/rx/internal/util/DiagnosticSpscQueue.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package rx.internal.util;
+
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+/**
+ * Queue that wraps the SPSC methods to check if they are used concurrently
+ * and throws an exception if so.
+ * @param <T> the element type
+ */
+public final class DiagnosticSpscQueue<T> extends AbstractQueue<T> {
+    final Queue<T> actual;
+    final AtomicInteger writers;
+    final AtomicInteger readers;
+    final AtomicReference<Thread> readerThread;
+    final AtomicReference<Thread> writerThread;
+    final boolean watchThread;
+    public DiagnosticSpscQueue(Queue<T> actual) {
+        this.actual = actual;
+        this.readers = new AtomicInteger();
+        this.writers = new AtomicInteger();
+        this.readerThread = new AtomicReference<Thread>();
+        this.writerThread = new AtomicReference<Thread>();
+        this.watchThread = true;
+    }
+    void sleep() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException ex) {
+            // ignored
+        }
+    }
+    void writerEnter() {
+        int wc = writers.incrementAndGet();
+        if (wc != 0) {
+            writers.decrementAndGet();
+            throw new IllegalStateException("Multiple writers on enter: " + wc);
+        }
+        sleep();
+    }
+    void writerLeave() {
+        int wc = writers.decrementAndGet();
+        if (wc != 0) {
+            throw new IllegalStateException("Multiple writers on enter: " + wc);
+        }
+    }
+    void readerEnter() {
+        int rc = readers.incrementAndGet();
+        if (rc != 0) {
+            throw new IllegalStateException("Multiple readers on enter: " + rc);
+        }
+        sleep();
+    }
+    void readerLeave() {
+        int rc = readers.decrementAndGet();
+        if (rc != 0) {
+            throw new IllegalStateException("Multiple writers on enter: " + rc);
+        }
+    }
+    @Override
+    public boolean offer(T e) {
+        try {
+            return actual.offer(e);
+        } finally {
+        }
+    }
+    @Override
+    public T poll() {
+        try {
+            return actual.poll();
+        } finally {
+        }
+    }
+    @Override
+    public T peek() {
+        try {
+            return actual.peek();
+        } finally {
+        }
+    }
+    @Override
+    public Iterator<T> iterator() {
+        return actual.iterator();
+    }
+    @Override
+    public int size() {
+        try {
+            return actual.size();
+        } finally {
+        }
+    }
+    
+}

--- a/src/main/java/rx/internal/util/RxRingBuffer.java
+++ b/src/main/java/rx/internal/util/RxRingBuffer.java
@@ -32,7 +32,7 @@ public class RxRingBuffer implements Subscription {
         Queue<Object> q;
         boolean bounded;
 //        if (UnsafeAccess.isUnsafeAvailable()) {
-//            q = new AtomicArrayQueueUnsafe(4, SIZE);
+//            q = new AtomicArrayQueue(4, SIZE);
 //            bounded = true;
 //        } else {
             q = new SpscLinkedQueue<Object>();
@@ -49,8 +49,9 @@ public class RxRingBuffer implements Subscription {
         boolean bounded;
         if (UnsafeAccess.isUnsafeAvailable()) {
 //            q = new AtomicArrayQueue(4, SIZE);
-//            q = new SpscArrayQueue<Object>(SIZE * 2); // the lookahead gives trouble with the effective capacity
-            q = new AtomicArrayQueueUnsafe(4, SIZE); // the lookahead gives trouble with the effective capacity
+            q = new SpscArrayQueue<Object>(SIZE * 2); // the lookahead gives trouble with the effective capacity
+//            q = new AtomicArrayQueuePadded(4, SIZE); // the lookahead gives trouble with the effective capacity
+//            q = new AtomicArrayQueueUnsafe(4, SIZE); // the lookahead gives trouble with the effective capacity
             bounded = true;
         } else {
             q = new SpscLinkedQueue<Object>();

--- a/src/main/java/rx/internal/util/RxRingBuffer.java
+++ b/src/main/java/rx/internal/util/RxRingBuffer.java
@@ -31,14 +31,14 @@ public class RxRingBuffer implements Subscription {
     public static RxRingBuffer getSpscInstance() {
         Queue<Object> q;
         boolean bounded;
-        if (UnsafeAccess.isUnsafeAvailable()) {
-            q = new AtomicArrayQueueUnsafe(4, SIZE);
-            bounded = true;
-        } else {
+//        if (UnsafeAccess.isUnsafeAvailable()) {
+//            q = new AtomicArrayQueueUnsafe(4, SIZE);
+//            bounded = true;
+//        } else {
             q = new SpscLinkedQueue<Object>();
             bounded = false;
-        }
-        q = new DiagnosticSpscQueue<Object>(q);
+//        }
+//        q = new DiagnosticSpscQueue<Object>(q, true);
         return new RxRingBuffer(q, SIZE, bounded);
     }
 
@@ -47,16 +47,16 @@ public class RxRingBuffer implements Subscription {
         // TODO right now this is returning an Spsc queue. Why did anything need Spmc before?
         Queue<Object> q;
         boolean bounded;
-//        if (UnsafeAccess.isUnsafeAvailable()) {
+        if (UnsafeAccess.isUnsafeAvailable()) {
 //            q = new AtomicArrayQueue(4, SIZE);
 //            q = new SpscArrayQueue<Object>(SIZE * 2); // the lookahead gives trouble with the effective capacity
             q = new AtomicArrayQueueUnsafe(4, SIZE); // the lookahead gives trouble with the effective capacity
             bounded = true;
-//        } else {
-//            q = new SpscLinkedQueue<Object>();
-//            bounded = false;
-//        }
-        q = new DiagnosticSpscQueue<Object>(q);
+        } else {
+            q = new SpscLinkedQueue<Object>();
+            bounded = false;
+        }
+//        q = new DiagnosticSpscQueue<Object>(q, false);
         return new RxRingBuffer(q, SIZE, bounded);
     }
 

--- a/src/main/java/rx/internal/util/RxRingBuffer.java
+++ b/src/main/java/rx/internal/util/RxRingBuffer.java
@@ -16,13 +16,11 @@
 package rx.internal.util;
 
 import java.util.Queue;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import rx.Observer;
-import rx.Subscription;
+import rx.*;
 import rx.exceptions.MissingBackpressureException;
 import rx.internal.operators.NotificationLite;
-import rx.internal.util.unsafe.SpscLinkedQueue;
+import rx.internal.util.unsafe.*;
 
 /**
  * This assumes Spsc or Spmc usage. This means only a single producer calling the on* methods. This is the Rx contract of an Observer.
@@ -31,13 +29,14 @@ import rx.internal.util.unsafe.SpscLinkedQueue;
 public class RxRingBuffer implements Subscription {
 
     public static RxRingBuffer getSpscInstance() {
+//        return new RxRingBuffer(new SpscLinkedQueue<Object>(), SIZE);
         return new RxRingBuffer(new SpscLinkedQueue<Object>(), SIZE);
     }
 
     @Deprecated
     public static RxRingBuffer getSpmcInstance() {
         // TODO right now this is returning an Spsc queue. Why did anything need Spmc before?
-        return new RxRingBuffer(new SpscLinkedQueue<Object>(), SIZE);
+        return new RxRingBuffer(new AtomicArrayQueueUnsafe2(4, SIZE), SIZE);
     }
 
     private static final NotificationLite<Object> on = NotificationLite.instance();
@@ -45,9 +44,15 @@ public class RxRingBuffer implements Subscription {
     private Queue<Object> queue;
 
     private final int size;
-    private volatile int _count = 0;
-    private static final AtomicIntegerFieldUpdater<RxRingBuffer> COUNT = AtomicIntegerFieldUpdater.newUpdater(RxRingBuffer.class, "_count"); 
-
+    
+    /** Keeps track how many items were produced. */
+    private long producerIndexCached;
+    /** Shows how many items were produced to other threads. */
+    private volatile long producerIndexShared;
+    /** Keeps track how many items were consumed. */
+    private long consumerIndexCached;
+    /** Shows how many items were consumed to other threads. */
+    private volatile long consumerIndexShared;
     /**
      * We store the terminal state separately so it doesn't count against the size.
      * We don't just +1 the size since some of the queues require sizes that are a power of 2.
@@ -202,15 +207,15 @@ public class RxRingBuffer implements Subscription {
      *             if more onNext are sent than have been requested
      */
     public void onNext(Object o) throws MissingBackpressureException {
-        if (queue == null) {
+        Queue<Object> q = queue;
+        if (q == null) {
             throw new IllegalStateException("This instance has been unsubscribed and the queue is no longer usable.");
         }
         
-        if(COUNT.incrementAndGet(this) <= size) {
-            queue.offer(on.next(o));
+        if(producerQueueSize() < size) {
+            produce();
+            q.offer(on.next(o));
         } else {
-            // decrement since we went over
-            COUNT.decrementAndGet(this);
             // throw exception since we exceeded size limit
             throw new MissingBackpressureException();
         }
@@ -242,28 +247,61 @@ public class RxRingBuffer implements Subscription {
         return size;
     }
 
+    /**
+     * @return Returns the queue size from the view of the producer.
+     */
+    protected int producerQueueSize() {
+        long diff = producerIndexCached - consumerIndexShared;
+        if (diff > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int)diff;
+    }
+    /**
+     * @return Returns the queue size from the view of the consumer.
+     */
+    protected int consumerQueueSize() {
+        long diff = producerIndexShared - consumerIndexCached;
+        if (diff > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int)diff;
+    }
+    protected void produce() {
+        producerIndexShared = ++producerIndexCached;
+    }
+    protected void consume() {
+        consumerIndexShared = ++consumerIndexCached;
+    }
+    
     public int count() {
         if (queue == null) {
             return 0;
         }
-        return _count;
+        long diff = producerIndexShared - consumerIndexShared;
+        if (diff > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int)diff;
 //        return queue.size();
     }
 
     public boolean isEmpty() {
-        if (queue == null) {
+        Queue<Object> q = queue;
+        if (q == null) {
             return true;
         }
-        return queue.isEmpty();
+        return q.isEmpty();
     }
 
     public Object poll() {
-        if (queue == null) {
+        Queue<Object> q = queue;
+        if (q == null) {
             // we are unsubscribed and have released the undelrying queue
             return null;
         }
         Object o;
-        o = queue.poll();
+        o = q.poll();
         /*
          * benjchristensen July 10 2014 => The check for 'queue.isEmpty()' came from a very rare concurrency bug where poll()
          * is invoked, then an "onNext + onCompleted/onError" arrives before hitting the if check below. In that case,
@@ -276,25 +314,26 @@ public class RxRingBuffer implements Subscription {
          * a +1 of the size, or -1 of how many onNext can be sent. See comment on 'terminalState' above for why it
          * is currently the way it is.
          */
-        if (o == null && terminalState != null && queue.isEmpty()) {
+        if (o == null && terminalState != null && q.isEmpty()) {
             o = terminalState;
             // once emitted we clear so a poll loop will finish
             terminalState = null;
         } else {
             // decrement when we drain
-            COUNT.decrementAndGet(this);
+            consume();
         }
         return o;
     }
 
     public Object peek() {
-        if (queue == null) {
+        Queue<Object> q = queue;
+        if (q == null) {
             // we are unsubscribed and have released the undelrying queue
             return null;
         }
         Object o;
-        o = queue.peek();
-        if (o == null && terminalState != null && queue.isEmpty()) {
+        o = q.peek();
+        if (o == null && terminalState != null && q.isEmpty()) {
             o = terminalState;
         }
         return o;

--- a/src/main/java/rx/internal/util/unsafe/AtomicArrayQueueUnsafe.java
+++ b/src/main/java/rx/internal/util/unsafe/AtomicArrayQueueUnsafe.java
@@ -125,7 +125,7 @@ public class AtomicArrayQueueUnsafe extends AbstractQueue<Object> {
 
         // move the front to the back
         boolean caughtUp = false;
-        long j = calcOffset(wi, n2 - 1) - arrayIndexSize;
+        long j = calcOffset(wi - 1, n2 - 1);
         for (long i = wo - arrayIndexSize; i >= arrayOffset; i -= arrayIndexSize, j -= arrayIndexSize) {
             Object o = lvElement(b, i);
             if (o == null || !casElement(b, i, o, TOMBSTONE)) {

--- a/src/main/java/rx/internal/util/unsafe/AtomicArrayQueueUnsafe2.java
+++ b/src/main/java/rx/internal/util/unsafe/AtomicArrayQueueUnsafe2.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.util.unsafe;
+
+import java.util.*;
+
+import rx.internal.util.PlatformDependent;
+
+/**
+ * A single-producer single-consumer circular array which resizes to a higher capacity once it fills
+ * its smaller buffer.
+ */
+public class AtomicArrayQueueUnsafe2 extends AbstractQueue<Object> {
+    static final Object TOMBSTONE = new Object();
+    static final long P_BUFFER;
+    static final long ARRAY_OFFSET;
+    static final int ARRAY_SCALE;
+    static final int ARRAY_INDEX_SIZE;
+    static final long HIGH_TRAFFIC_QUEUE_THRESHOLD;
+    static {
+        long _size = 128;
+        if (PlatformDependent.isAndroid()) {
+            _size = Long.MAX_VALUE;
+        }
+
+        // possible system property for overriding
+        String sizeFromProperty = System.getProperty("rx.ring-buffer.resize-traffic");
+        if (sizeFromProperty != null) {
+            try {
+                _size = Integer.parseInt(sizeFromProperty);
+            } catch (Exception e) {
+                System.err.println("Failed to set 'rx.ring-buffer.resize-traffic' with value " + sizeFromProperty + " => " + e.getMessage());
+            }
+        }
+        HIGH_TRAFFIC_QUEUE_THRESHOLD = _size;
+        
+        try {
+            P_BUFFER = UnsafeAccess.UNSAFE.objectFieldOffset(AtomicArrayQueueUnsafe2.class.getDeclaredField("buffer"));
+        } catch (NoSuchFieldException ex) {
+            throw new RuntimeException();
+        }
+        int is = UnsafeAccess.UNSAFE.arrayIndexScale(Object[].class);
+        int as;
+        if (is == 4) {
+            as = 2;
+        } else
+            if (is == 8) {
+                as = 3;
+            } else {
+                throw new RuntimeException("Unsupported array index scale: " + is);
+            }
+
+        ARRAY_SCALE = as;
+        ARRAY_INDEX_SIZE = is;
+        ARRAY_OFFSET = UnsafeAccess.UNSAFE.arrayBaseOffset(Object[].class);
+    }
+    Object[] buffer;
+    long readerIndex;
+    long writerIndex;
+    final int maxCapacity;
+    private Object[] lpBuffer() {
+        return (Object[])UnsafeAccess.UNSAFE.getObject(this, P_BUFFER);
+    }
+    private Object[] lvBuffer() {
+        return (Object[])UnsafeAccess.UNSAFE.getObjectVolatile(this, P_BUFFER);
+    }
+    private void soBuffer(Object[] buffer) {
+        UnsafeAccess.UNSAFE.putOrderedObject(this, P_BUFFER, buffer);
+    }
+    private Object lvElement(Object[] buffer, long offset) {
+        return UnsafeAccess.UNSAFE.getObjectVolatile(buffer, offset);
+    }
+    private void soElement(Object[] buffer, long offset, Object value) {
+        UnsafeAccess.UNSAFE.putOrderedObject(buffer, offset, value);
+    }
+    private boolean casElement(Object[] buffer, long offset, Object expected, Object value) {
+        return UnsafeAccess.UNSAFE.compareAndSwapObject(buffer, offset, expected, value);
+    }
+
+    private long calcOffset(long index, int mask) {
+        return ARRAY_OFFSET + ((index & mask) << ARRAY_SCALE);
+    }
+    static int roundToPowerOfTwo(final int value) {
+        return 1 << (32 - Integer.numberOfLeadingZeros(value - 1));
+    }
+
+    public AtomicArrayQueueUnsafe2(int initialCapacity, int maxCapacity) {
+        int c0;
+        if (initialCapacity >= 1 << 30) {
+            c0 = 1 << 30;
+        } else {
+            c0 = roundToPowerOfTwo(initialCapacity);
+        }
+        int cm;
+        if (maxCapacity >= 1 << 30) {
+            cm = 1 << 30;
+        } else {
+            cm = roundToPowerOfTwo(maxCapacity);
+        }
+        this.maxCapacity = cm;
+
+        soBuffer(new Object[c0]);;
+    }
+
+    Object[] grow(Object[] b, long wo, int n, int n2) {
+
+        int arrayScale = ARRAY_SCALE;
+        int arrayIndexSize = ARRAY_INDEX_SIZE;
+        long arrayOffset = ARRAY_OFFSET;
+        Object[] b2 = new Object[n2];
+
+        // move the front to the back
+        boolean caughtUp = false;
+        for (long i = wo - arrayIndexSize, j = wo + (n << arrayScale); i >= arrayOffset; i -= arrayIndexSize, j -= arrayIndexSize) {
+            Object o = lvElement(b, i);
+            if (o == null || !casElement(b, i, o, TOMBSTONE)) {
+                caughtUp = true;
+                break;
+            } else
+            soElement(b2, j, o);
+        }
+        // leave everything beyont the wrap point at its location
+        if (!caughtUp) {
+            long no = arrayOffset + (n << arrayScale);
+            for (long i = no; i >= wo; i -= arrayIndexSize) {
+                Object o = lvElement(b, i);
+                if (o == null || !casElement(b, i, o, TOMBSTONE)) {
+                    break;
+                }
+                soElement(b2, i, o);
+            }
+        }
+
+        soBuffer(b2);
+
+        return b2;
+    }
+
+    @Override
+    public boolean offer(Object o) {
+        long wi = writerIndex;
+
+        Object[] b = lpBuffer();
+
+        int n = b.length - 1;
+        long wo = calcOffset(wi, n);
+        if (lvElement(b, wo) != null || wi >= HIGH_TRAFFIC_QUEUE_THRESHOLD) {
+            int q = maxCapacity;
+            if (n + 1 == q) {
+                return false;
+            }
+            // grow
+            b = grow(b, wo, n, q);
+            wo = calcOffset(wi, q - 1);
+        }
+        soElement(b, wo, o);
+
+        writerIndex = wi + 1;
+
+        return true;
+    }
+    @Override
+    public Object poll() {
+        long ri = readerIndex;
+        Object[] b = lpBuffer();
+        for (;;) {
+            int mask = b.length - 1;
+            long ro = calcOffset(ri, mask);
+
+            Object o = lvElement(b, ro);
+            if (o == null) {
+                return null;
+            }
+            if (mask + 1 == maxCapacity) {
+                soElement(b, ro, null);
+            } else
+            if (o == TOMBSTONE || !casElement(b, ro, o, null)) {
+                b = lvBuffer();
+                continue;
+            }
+            readerIndex = ri + 1;
+            return o;
+        }
+    }
+    @Override
+    public Object peek() {
+        long ri = readerIndex;
+        Object[] b = lpBuffer();
+        for (;;) {
+            int mask = b.length - 1;
+            long ro = calcOffset(ri, mask);
+
+            Object o = lvElement(b, ro);
+            if (o != TOMBSTONE) {
+                return o;
+            }
+            b = lvBuffer();
+        }
+    }
+    @Override
+    public boolean isEmpty() {
+        return peek() == null;
+    }
+    @Override
+    public int size() {
+        int size = 0;
+        long ri = readerIndex;
+        Object[] b = lpBuffer();
+        for (;;) {
+            int mask = b.length - 1;
+            long ro = calcOffset(ri, mask);
+            Object o = lvElement(b, ro);
+            if (o == null) {
+                return size;
+            } else
+            if (o == TOMBSTONE) {
+                b = lvBuffer();
+                continue;
+            }
+            size++;
+            ri++;
+        }
+    }
+    @Override
+    public Iterator<Object> iterator() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/perf/java/rx/internal/RxRingBufferPerf.java
+++ b/src/perf/java/rx/internal/RxRingBufferPerf.java
@@ -28,6 +28,9 @@ import rx.exceptions.MissingBackpressureException;
 import rx.internal.util.RxRingBuffer;
 import rx.jmh.InputWithIncrementingInteger;
 
+/**
+ * gradlew benchmarks "-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*RxRingBufferPerf.*"
+ */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 public class RxRingBufferPerf {
@@ -40,10 +43,10 @@ public class RxRingBufferPerf {
 
     @Benchmark
     public void spmcRingBufferAddRemove1000(SpmcInput input) throws InterruptedException, MissingBackpressureException {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.ring.onNext("a");
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.bh.consume(input.ring.poll());
         }
     }
@@ -51,10 +54,10 @@ public class RxRingBufferPerf {
     @Benchmark
     public void spmcCreateUseAndDestroy1000(Input input) throws InterruptedException, MissingBackpressureException {
         RxRingBuffer buffer = RxRingBuffer.getSpmcInstance();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             buffer.onNext("a");
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.bh.consume(buffer.poll());
         }
         buffer.release();
@@ -76,10 +79,10 @@ public class RxRingBufferPerf {
 
     @Benchmark
     public void spscRingBufferAddRemove1000(SpscInput input) throws InterruptedException, MissingBackpressureException {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.ring.onNext("a");
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.bh.consume(input.ring.poll());
         }
     }
@@ -87,10 +90,10 @@ public class RxRingBufferPerf {
     @Benchmark
     public void spscCreateUseAndDestroy1000(Input input) throws InterruptedException, MissingBackpressureException {
         RxRingBuffer buffer = RxRingBuffer.getSpscInstance();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             buffer.onNext("a");
         }
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
             input.bh.consume(buffer.poll());
         }
         buffer.release();

--- a/src/test/java/rx/BackpressureTests.java
+++ b/src/test/java/rx/BackpressureTests.java
@@ -180,7 +180,9 @@ public class BackpressureTests {
         // even though we only need 10, it will request at least RxRingBuffer.SIZE, and then as it drains keep requesting more
         // and then it will be non-deterministic when the take() causes the unsubscribe as it is scheduled on 10 different schedulers (threads)
         // normally this number is ~250 but can get up to ~1200 when RxRingBuffer.SIZE == 1024
-        assertTrue(c.get() <= RxRingBuffer.SIZE * 2);
+        int actual = c.get();
+        int expected = RxRingBuffer.SIZE * 2;
+        assertTrue("actual = " + actual + " > " + expected, actual <= expected);
     }
 
     @Test

--- a/src/test/java/rx/internal/util/AtomicArrayQueuePaddedTest.java
+++ b/src/test/java/rx/internal/util/AtomicArrayQueuePaddedTest.java
@@ -1,0 +1,135 @@
+package rx.internal.util;
+
+import static org.junit.Assert.*;
+
+import java.util.Queue;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import rx.exceptions.MissingBackpressureException;
+
+public class AtomicArrayQueuePaddedTest {
+    @Test
+    public void testSimpleOfferPoll() {
+        Queue<Object> saq = new AtomicArrayQueuePadded(8, 64 * 1024);
+        for (int i = 0; i < 10000; i++) {
+            saq.offer(i);
+            assertEquals(i, saq.poll());
+        }
+    }
+    @Test
+    public void testTriggerOneGrowth() {
+        Queue<Object> saq = new AtomicArrayQueuePadded(8, 64 * 1024);
+        for (int i = 0; i < 16; i++) {
+            saq.offer(i);
+        }
+        for (int i = 0; i < 16; i++) {
+            assertEquals(i, saq.poll());
+        }       
+    }
+    @Test
+    public void testTriggerGrowthHalfwayReading() {
+        Queue<Object> saq = new AtomicArrayQueuePadded(8, 16);
+        for (int i = 0; i < 4; i++) {
+            saq.offer(i);
+        }
+        for (int i = 0; i < 4; i++) {
+            assertEquals(i, saq.poll());
+        }
+        for (int i = 4; i < 16; i++) {
+            saq.offer(i);
+        }
+        for (int i = 4; i < 16; i++) {
+            assertEquals(i, saq.poll());
+        }
+    }
+
+    @Test
+    public void testCapacityLimit() {
+        Queue<Object> aaq = new AtomicArrayQueuePadded(8, 16);
+        for (int i = 0; i < 16; i++) {
+            assertTrue(aaq.offer(i));
+        }
+        assertFalse(aaq.offer(16));
+        
+        assertEquals(0, aaq.poll());
+
+        assertTrue(aaq.offer(16));
+
+    }
+    
+    static void await(CyclicBarrier cb) {
+        try {
+            cb.await();
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        } catch (BrokenBarrierException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
+    @Test(timeout = 10000)
+    public void testConcurrentBehavior() throws InterruptedException {
+        for (int j = 0; j < 50; j++) {
+            final Queue<Object> aaq = new AtomicArrayQueuePadded(8, 64 * 1024);
+            
+            final AtomicBoolean continuous = new AtomicBoolean(true);
+            
+            final int m = 1000 * 1000;
+            
+            final CyclicBarrier cb = new CyclicBarrier(2);
+            
+            Thread t1 = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    await(cb);
+                    for (int i = 0; i < m; i++) {
+                        aaq.offer(i);
+                    }
+                    System.out.println("Offer done.");
+                }
+            });
+    
+            Thread t2 = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    await(cb);
+                    int last = -1;
+                    while (!Thread.currentThread().isInterrupted() && last + 1 == m) {
+                        Integer o = (Integer)aaq.poll();
+                        if (o != null) {
+                            int last0 = last;
+                            last = o;
+                            if (last0 + 1 != o) {
+                                System.out.println("Discontinuity! " + last0 + " -> " + last);
+                                continuous.set(false);
+                                return;
+                            }
+                        }
+                    }
+                    System.out.println("Poll done.");
+                }
+            });
+            
+            t1.start();
+            t2.start();
+    
+            t1.join();
+            t2.join();
+            
+            assertTrue("Discontinuity!", continuous.get());
+        }
+    }
+    @Test
+    public void asRingBufferAddRemove1000() throws InterruptedException, MissingBackpressureException {
+        RxRingBuffer ring = new RxRingBuffer(new AtomicArrayQueuePadded(4, RxRingBuffer.SIZE), RxRingBuffer.SIZE, true);
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
+            ring.onNext("a");
+        }
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
+            assertEquals("a", ring.poll());
+        }
+    }
+}

--- a/src/test/java/rx/internal/util/AtomicArrayQueuePaddedTest.java
+++ b/src/test/java/rx/internal/util/AtomicArrayQueuePaddedTest.java
@@ -134,7 +134,7 @@ public class AtomicArrayQueuePaddedTest {
     }
     @Test
     public void testSize() {
-        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        AtomicArrayQueuePadded queue = new AtomicArrayQueuePadded(4, 16);
         for (int i = 0; i < 2; i++) {
             assertTrue(queue.offer(i));
         }
@@ -142,7 +142,7 @@ public class AtomicArrayQueuePaddedTest {
     }
     @Test
     public void testSizeAfterGrowth() {
-        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        AtomicArrayQueuePadded queue = new AtomicArrayQueuePadded(4, 16);
         for (int i = 0; i < 12; i++) {
             assertTrue(queue.offer(i));
         }
@@ -150,7 +150,7 @@ public class AtomicArrayQueuePaddedTest {
     }
     @Test
     public void testPeek() {
-        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        AtomicArrayQueuePadded queue = new AtomicArrayQueuePadded(4, 16);
         queue.offer(1);
         for (int i = 0; i < 10; i++) {
             assertEquals(1, queue.peek());
@@ -163,7 +163,7 @@ public class AtomicArrayQueuePaddedTest {
     }
     @Test
     public void testPeekBeforeAfterGrow() {
-        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        AtomicArrayQueuePadded queue = new AtomicArrayQueuePadded(4, 16);
         queue.offer(1);
         queue.offer(2);
         queue.offer(3);

--- a/src/test/java/rx/internal/util/AtomicArrayQueuePaddedTest.java
+++ b/src/test/java/rx/internal/util/AtomicArrayQueuePaddedTest.java
@@ -132,4 +132,55 @@ public class AtomicArrayQueuePaddedTest {
             assertEquals("a", ring.poll());
         }
     }
+    @Test
+    public void testSize() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        for (int i = 0; i < 2; i++) {
+            assertTrue(queue.offer(i));
+        }
+        assertEquals(2, queue.size());
+    }
+    @Test
+    public void testSizeAfterGrowth() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        for (int i = 0; i < 12; i++) {
+            assertTrue(queue.offer(i));
+        }
+        assertEquals(12, queue.size());
+    }
+    @Test
+    public void testPeek() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        queue.offer(1);
+        for (int i = 0; i < 10; i++) {
+            assertEquals(1, queue.peek());
+        }
+        assertEquals(1, queue.poll());
+        for (int i = 0; i < 10; i++) {
+            assertEquals(null, queue.peek());
+        }
+        assertEquals(null, queue.poll());
+    }
+    @Test
+    public void testPeekBeforeAfterGrow() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(3);
+        queue.offer(4);
+        
+        assertEquals(1, queue.peek());
+
+        queue.offer(5);
+        queue.offer(6);
+        queue.offer(7);
+        queue.offer(8);
+        
+        queue.poll();
+        queue.poll();
+        queue.poll();
+        queue.poll();
+        
+        assertEquals(5, queue.peek());
+    }
 }

--- a/src/test/java/rx/internal/util/AtomicArrayQueueTest.java
+++ b/src/test/java/rx/internal/util/AtomicArrayQueueTest.java
@@ -1,0 +1,135 @@
+package rx.internal.util;
+
+import static org.junit.Assert.*;
+
+import java.util.Queue;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import rx.exceptions.MissingBackpressureException;
+
+public class AtomicArrayQueueTest {
+    @Test
+    public void testSimpleOfferPoll() {
+        Queue<Object> saq = new AtomicArrayQueue(8, 64 * 1024);
+        for (int i = 0; i < 10000; i++) {
+            saq.offer(i);
+            assertEquals(i, saq.poll());
+        }
+    }
+    @Test
+    public void testTriggerOneGrowth() {
+        Queue<Object> saq = new AtomicArrayQueue(8, 64 * 1024);
+        for (int i = 0; i < 16; i++) {
+            saq.offer(i);
+        }
+        for (int i = 0; i < 16; i++) {
+            assertEquals(i, saq.poll());
+        }       
+    }
+    @Test
+    public void testTriggerGrowthHalfwayReading() {
+        Queue<Object> saq = new AtomicArrayQueue(8, 16);
+        for (int i = 0; i < 4; i++) {
+            saq.offer(i);
+        }
+        for (int i = 0; i < 4; i++) {
+            assertEquals(i, saq.poll());
+        }
+        for (int i = 4; i < 16; i++) {
+            saq.offer(i);
+        }
+        for (int i = 4; i < 16; i++) {
+            assertEquals(i, saq.poll());
+        }
+    }
+
+    @Test
+    public void testCapacityLimit() {
+        Queue<Object> aaq = new AtomicArrayQueue(8, 16);
+        for (int i = 0; i < 16; i++) {
+            assertTrue(aaq.offer(i));
+        }
+        assertFalse(aaq.offer(16));
+        
+        assertEquals(0, aaq.poll());
+
+        assertTrue(aaq.offer(16));
+
+    }
+    
+    static void await(CyclicBarrier cb) {
+        try {
+            cb.await();
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        } catch (BrokenBarrierException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
+    @Test(timeout = 10000)
+    public void testConcurrentBehavior() throws InterruptedException {
+        for (int j = 0; j < 50; j++) {
+            final Queue<Object> aaq = new AtomicArrayQueue(8, 64 * 1024);
+            
+            final AtomicBoolean continuous = new AtomicBoolean(true);
+            
+            final int m = 1000 * 1000;
+            
+            final CyclicBarrier cb = new CyclicBarrier(2);
+            
+            Thread t1 = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    await(cb);
+                    for (int i = 0; i < m; i++) {
+                        aaq.offer(i);
+                    }
+                    System.out.println("Offer done.");
+                }
+            });
+    
+            Thread t2 = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    await(cb);
+                    int last = -1;
+                    while (!Thread.currentThread().isInterrupted() && last + 1 == m) {
+                        Integer o = (Integer)aaq.poll();
+                        if (o != null) {
+                            int last0 = last;
+                            last = o;
+                            if (last0 + 1 != o) {
+                                System.out.println("Discontinuity! " + last0 + " -> " + last);
+                                continuous.set(false);
+                                return;
+                            }
+                        }
+                    }
+                    System.out.println("Poll done.");
+                }
+            });
+            
+            t1.start();
+            t2.start();
+    
+            t1.join();
+            t2.join();
+            
+            assertTrue("Discontinuity!", continuous.get());
+        }
+    }
+    @Test
+    public void asRingBufferAddRemove1000() throws InterruptedException, MissingBackpressureException {
+        RxRingBuffer ring = new RxRingBuffer(new AtomicArrayQueue(4, RxRingBuffer.SIZE), RxRingBuffer.SIZE, true);
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
+            ring.onNext("a");
+        }
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
+            assertEquals("a", ring.poll());
+        }
+    }
+}

--- a/src/test/java/rx/internal/util/AtomicArrayQueueTest.java
+++ b/src/test/java/rx/internal/util/AtomicArrayQueueTest.java
@@ -132,4 +132,55 @@ public class AtomicArrayQueueTest {
             assertEquals("a", ring.poll());
         }
     }
+    @Test
+    public void testSize() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        for (int i = 0; i < 2; i++) {
+            assertTrue(queue.offer(i));
+        }
+        assertEquals(2, queue.size());
+    }
+    @Test
+    public void testSizeAfterGrowth() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        for (int i = 0; i < 12; i++) {
+            assertTrue(queue.offer(i));
+        }
+        assertEquals(12, queue.size());
+    }
+    @Test
+    public void testPeek() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        queue.offer(1);
+        for (int i = 0; i < 10; i++) {
+            assertEquals(1, queue.peek());
+        }
+        assertEquals(1, queue.poll());
+        for (int i = 0; i < 10; i++) {
+            assertEquals(null, queue.peek());
+        }
+        assertEquals(null, queue.poll());
+    }
+    @Test
+    public void testPeekBeforeAfterGrow() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(3);
+        queue.offer(4);
+        
+        assertEquals(1, queue.peek());
+
+        queue.offer(5);
+        queue.offer(6);
+        queue.offer(7);
+        queue.offer(8);
+        
+        queue.poll();
+        queue.poll();
+        queue.poll();
+        queue.poll();
+        
+        assertEquals(5, queue.peek());
+    }
 }

--- a/src/test/java/rx/internal/util/AtomicArrayQueueUnsafeTest.java
+++ b/src/test/java/rx/internal/util/AtomicArrayQueueUnsafeTest.java
@@ -133,4 +133,55 @@ public class AtomicArrayQueueUnsafeTest {
             assertEquals("a", ring.poll());
         }
     }
+    @Test
+    public void testSize() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        for (int i = 0; i < 2; i++) {
+            assertTrue(queue.offer(i));
+        }
+        assertEquals(2, queue.size());
+    }
+    @Test
+    public void testSizeAfterGrowth() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        for (int i = 0; i < 12; i++) {
+            assertTrue(queue.offer(i));
+        }
+        assertEquals(12, queue.size());
+    }
+    @Test
+    public void testPeek() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        queue.offer(1);
+        for (int i = 0; i < 10; i++) {
+            assertEquals(1, queue.peek());
+        }
+        assertEquals(1, queue.poll());
+        for (int i = 0; i < 10; i++) {
+            assertEquals(null, queue.peek());
+        }
+        assertEquals(null, queue.poll());
+    }
+    @Test
+    public void testPeekBeforeAfterGrow() {
+        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(3);
+        queue.offer(4);
+        
+        assertEquals(1, queue.peek());
+
+        queue.offer(5);
+        queue.offer(6);
+        queue.offer(7);
+        queue.offer(8);
+        
+        queue.poll();
+        queue.poll();
+        queue.poll();
+        queue.poll();
+        
+        assertEquals(5, queue.peek());
+    }
 }

--- a/src/test/java/rx/internal/util/AtomicArrayQueueUnsafeTest.java
+++ b/src/test/java/rx/internal/util/AtomicArrayQueueUnsafeTest.java
@@ -1,0 +1,136 @@
+package rx.internal.util;
+
+import static org.junit.Assert.*;
+
+import java.util.Queue;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import rx.exceptions.MissingBackpressureException;
+import rx.internal.util.unsafe.AtomicArrayQueueUnsafe;
+
+public class AtomicArrayQueueUnsafeTest {
+    @Test
+    public void testSimpleOfferPoll() {
+        Queue<Object> saq = new AtomicArrayQueueUnsafe(8, 64 * 1024);
+        for (int i = 0; i < 10000; i++) {
+            saq.offer(i);
+            assertEquals(i, saq.poll());
+        }
+    }
+    @Test
+    public void testTriggerOneGrowth() {
+        Queue<Object> saq = new AtomicArrayQueueUnsafe(8, 64 * 1024);
+        for (int i = 0; i < 16; i++) {
+            saq.offer(i);
+        }
+        for (int i = 0; i < 16; i++) {
+            assertEquals(i, saq.poll());
+        }       
+    }
+    @Test
+    public void testTriggerGrowthHalfwayReading() {
+        Queue<Object> saq = new AtomicArrayQueueUnsafe(8, 16);
+        for (int i = 0; i < 4; i++) {
+            saq.offer(i);
+        }
+        for (int i = 0; i < 4; i++) {
+            assertEquals(i, saq.poll());
+        }
+        for (int i = 4; i < 16; i++) {
+            saq.offer(i);
+        }
+        for (int i = 4; i < 16; i++) {
+            assertEquals(i, saq.poll());
+        }
+    }
+
+    @Test
+    public void testCapacityLimit() {
+        Queue<Object> aaq = new AtomicArrayQueueUnsafe(8, 16);
+        for (int i = 0; i < 16; i++) {
+            assertTrue(aaq.offer(i));
+        }
+        assertFalse(aaq.offer(16));
+        
+        assertEquals(0, aaq.poll());
+
+        assertTrue(aaq.offer(16));
+
+    }
+    
+    static void await(CyclicBarrier cb) {
+        try {
+            cb.await();
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        } catch (BrokenBarrierException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
+    @Test(timeout = 10000)
+    public void testConcurrentBehavior() throws InterruptedException {
+        for (int j = 0; j < 50; j++) {
+            final Queue<Object> aaq = new AtomicArrayQueueUnsafe(8, 64 * 1024);
+            
+            final AtomicBoolean continuous = new AtomicBoolean(true);
+            
+            final int m = 1000 * 1000;
+            
+            final CyclicBarrier cb = new CyclicBarrier(2);
+            
+            Thread t1 = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    await(cb);
+                    for (int i = 0; i < m; i++) {
+                        aaq.offer(i);
+                    }
+                    System.out.println("Offer done.");
+                }
+            });
+    
+            Thread t2 = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    await(cb);
+                    int last = -1;
+                    while (!Thread.currentThread().isInterrupted() && last + 1 == m) {
+                        Integer o = (Integer)aaq.poll();
+                        if (o != null) {
+                            int last0 = last;
+                            last = o;
+                            if (last0 + 1 != o) {
+                                System.out.println("Discontinuity! " + last0 + " -> " + last);
+                                continuous.set(false);
+                                return;
+                            }
+                        }
+                    }
+                    System.out.println("Poll done.");
+                }
+            });
+            
+            t1.start();
+            t2.start();
+    
+            t1.join();
+            t2.join();
+            
+            assertTrue("Discontinuity!", continuous.get());
+        }
+    }
+    @Test
+    public void asRingBufferAddRemove1000() throws InterruptedException, MissingBackpressureException {
+        RxRingBuffer ring = new RxRingBuffer(new AtomicArrayQueueUnsafe(4, RxRingBuffer.SIZE), RxRingBuffer.SIZE, true);
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
+            ring.onNext("a");
+        }
+        for (int i = 0; i < RxRingBuffer.SIZE; i++) {
+            assertEquals("a", ring.poll());
+        }
+    }
+}

--- a/src/test/java/rx/internal/util/AtomicArrayQueueUnsafeTest.java
+++ b/src/test/java/rx/internal/util/AtomicArrayQueueUnsafeTest.java
@@ -135,7 +135,7 @@ public class AtomicArrayQueueUnsafeTest {
     }
     @Test
     public void testSize() {
-        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        AtomicArrayQueueUnsafe queue = new AtomicArrayQueueUnsafe(4, 16);
         for (int i = 0; i < 2; i++) {
             assertTrue(queue.offer(i));
         }
@@ -143,7 +143,7 @@ public class AtomicArrayQueueUnsafeTest {
     }
     @Test
     public void testSizeAfterGrowth() {
-        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        AtomicArrayQueueUnsafe queue = new AtomicArrayQueueUnsafe(4, 16);
         for (int i = 0; i < 12; i++) {
             assertTrue(queue.offer(i));
         }
@@ -151,7 +151,7 @@ public class AtomicArrayQueueUnsafeTest {
     }
     @Test
     public void testPeek() {
-        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        AtomicArrayQueueUnsafe queue = new AtomicArrayQueueUnsafe(4, 16);
         queue.offer(1);
         for (int i = 0; i < 10; i++) {
             assertEquals(1, queue.peek());
@@ -164,7 +164,7 @@ public class AtomicArrayQueueUnsafeTest {
     }
     @Test
     public void testPeekBeforeAfterGrow() {
-        AtomicArrayQueue queue = new AtomicArrayQueue(4, 16);
+        AtomicArrayQueueUnsafe queue = new AtomicArrayQueueUnsafe(4, 16);
         queue.offer(1);
         queue.offer(2);
         queue.offer(3);

--- a/src/test/java/rx/internal/util/RxRingBufferSpmcTest.java
+++ b/src/test/java/rx/internal/util/RxRingBufferSpmcTest.java
@@ -20,10 +20,9 @@ import static org.junit.Assert.assertEquals;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.*;
 
-import rx.Producer;
-import rx.Scheduler;
+import rx.*;
 import rx.exceptions.MissingBackpressureException;
 import rx.functions.Action0;
 import rx.observers.TestSubscriber;
@@ -40,6 +39,7 @@ public class RxRingBufferSpmcTest extends RxRingBufferBase {
      * Single producer, 2 consumers. The request() ensures it gets scheduled back on the same Producer thread.
      */
     @Test
+    @Ignore // won't work with spsc
     public void testConcurrency() throws InterruptedException {
         final RxRingBuffer b = createRingBuffer();
         final CountDownLatch emitLatch = new CountDownLatch(255);


### PR DESCRIPTION
I apologize if I flood you or the project with PRs, I'll respect a backpressure if necessary.

I've repost this PR because the original didn't actually work, but now I'm more confident this works.

I've implemented 3 resizing atomic array queues:
- `AtomicArrayQueue` with plain java atomic classes (aaqn)
- `AtomicArrayQueueUnsafe` with Unsafe atomics (aaqu)
- `AtomicArrayQueuePadded` with element padding, but no field padding. (aaqp)

and benchmarked them against SpscArrayQueue (spaq) and SpscLinkedQueue (spsc):

```
Benchmark                              Mode  Samples         Score  Score error    Units
r.i.RP.aaquCreateUseAndDestroy1       thrpt        5  27520602,070   504571,165    ops/s
r.i.RP.aaquCreateUseAndDestroy1000    thrpt        5    662582,205    64579,721    ops/s
r.i.RP.aaquRingBufferAddRemove1       thrpt        5  84642026,650  2470577,363    ops/s
r.i.RP.aaquRingBufferAddRemove1000    thrpt        5    475414,152     9822,705    ops/s

r.i.RP.aaqpCreateUseAndDestroy1       thrpt        5  17584287,989   597101,740    ops/s
r.i.RP.aaqpCreateUseAndDestroy1000    thrpt        5    267384,086     6985,954    ops/s
r.i.RP.aaqpRingBufferAddRemove1       thrpt        5  52889272,696   590511,776    ops/s
r.i.RP.aaqpRingBufferAddRemove1000    thrpt        5    360241,617     6047,325    ops/s

r.i.RP.aaqnCreateUseAndDestroy1       thrpt        5  23171385,086   448760,659    ops/s
r.i.RP.aaqnCreateUseAndDestroy1000    thrpt        5    318566,102     6294,829    ops/s
r.i.RP.aaqnRingBufferAddRemove1       thrpt        5  54069982,058   758327,742    ops/s
r.i.RP.aaqnRingBufferAddRemove1000    thrpt        5    375933,487     6271,312    ops/s

r.i.RP.spscCreateUseAndDestroy1       thrpt        5  10959175,709   113356,136    ops/s
r.i.RP.spscCreateUseAndDestroy1000    thrpt        5    314820,879     4632,766    ops/s
r.i.RP.spscRingBufferAddRemove1       thrpt        5  41398169,060   747113,735    ops/s
r.i.RP.spscRingBufferAddRemove1000    thrpt        5    327144,015    15522,612    ops/s

r.i.RP.spaqCreateUseAndDestroy1       thrpt        5   2990478,364    90732,967    ops/s
r.i.RP.spaqCreateUseAndDestroy1000    thrpt        5    732780,351    13201,861    ops/s
r.i.RP.spaqRingBufferAddRemove1       thrpt        5 108916574,580  1102474,342    ops/s
r.i.RP.spaqRingBufferAddRemove1000    thrpt        5    832670,999     9548,087    ops/s
```

The `AtomicArrayQueueUnsafe` was the quickest in the single-use scenario and performed quite well in the other cases. Removing the counters for the bounded queues gives great performance for improvement over the unbounded `SpscLinkedQueue`. The worst singe-use was the `SpscArrayQueue` because one single allocation takes up large amounts of memory due to padding. In addition, in order to compensate for its look-ahead capability (which makes the effective queue capacity less), the capacity had to be doubled so `MissingBackpressureException` is not thrown. Otherwise, it shines in prolonged use with great performance. The normal-atomics `AtomicArrayQueue` gives good single-use and moderate prolonged use performance; it mostly outruns `SpscLinkedQueue`. The `AtomicArrayQueuePadded` with its long class hierarchy seems to increase the instantiation cost. The spacing between the elements increase the cache/memory pressure in single threaded use.

So in conclusion, I'd go for `AtomicArrayQueueUnsafe` and `AtomicArrayQueue` as these give reasonable overall edge to the others. I'd say the lack of padding might not be of a big issue because in our scenarios, it is likely the one who offers the element will poll it as well.
